### PR TITLE
allow remarkable-fs toconvert to local folders

### DIFF
--- a/remarkable_fs/__init__.py
+++ b/remarkable_fs/__init__.py
@@ -18,9 +18,12 @@ def main(argv = sys.argv):
 
     print("Connecting to reMarkable...")
     with connect(*argv[2:]) as conn:
-        root = DocumentRoot(conn)
-        print("Now serving documents at " + mount_point)
-        kwargs={}
-        if fuse.system() == "Darwin":
-            kwargs["volname"] = "reMarkable"
-        mount(mount_point, root, **kwargs)
+        connect_to(DocumentRoot, conn, mount_point)
+
+def connect_to(connection_object, parameter, mount_point):
+    root = connection_object(parameter)
+    print("Now serving documents at " + mount_point)
+    kwargs={}
+    if fuse.system() == "Darwin":
+        kwargs["volname"] = "reMarkable"
+    mount(mount_point, root, **kwargs)

--- a/remarkable_fs/__init__.py
+++ b/remarkable_fs/__init__.py
@@ -3,6 +3,7 @@ from remarkable_fs.documents import DocumentRoot, DocumentRootDir
 from remarkable_fs.fs import mount
 import sys
 import fuse
+import os
 
 try:
     import __builtin__
@@ -26,7 +27,9 @@ def main(argv = sys.argv):
         with connect(*argv[2:]) as conn:
             connect_to(DocumentRoot, conn, mount_point)
     else:
-        connect_to(DocumentRootDir, remarkable_mount_point, mount_point)
+        mount_point = os.path.abspath(mount_point)
+        os.chdir( remarkable_mount_point )
+        connect_to(DocumentRootDir, None, mount_point)
 
 def connect_to(connection_object, parameter, mount_point):
     root = connection_object(parameter)

--- a/remarkable_fs/__init__.py
+++ b/remarkable_fs/__init__.py
@@ -1,5 +1,5 @@
 from remarkable_fs.connection import connect
-from remarkable_fs.documents import DocumentRoot
+from remarkable_fs.documents import DocumentRoot, DocumentRootDir
 from remarkable_fs.fs import mount
 import sys
 import fuse
@@ -11,14 +11,22 @@ except:
     raw_input = input
 
 def main(argv = sys.argv):
-    if len(argv) >= 2:
+    if len(argv) == 2:
         mount_point = argv[1]
+        remarkable_mount_point = None
+    elif len(argv) >= 3:
+        mount_point = argv[1]
+        remarkable_mount_point = argv[2]
     else:
-        mount_point = raw_input("Directory: ")
+        mount_point = raw_input("User Directory: ")
+        remarkable_mount_point = raw_input("ReMarkable Directory (press enter for automatic ssh connection): ")
 
     print("Connecting to reMarkable...")
-    with connect(*argv[2:]) as conn:
-        connect_to(DocumentRoot, conn, mount_point)
+    if remarkable_mount_point == None:
+        with connect(*argv[2:]) as conn:
+            connect_to(DocumentRoot, conn, mount_point)
+    else:
+        connect_to(DocumentRootDir, remarkable_mount_point, mount_point)
 
 def connect_to(connection_object, parameter, mount_point):
     root = connection_object(parameter)

--- a/remarkable_fs/__init__.py
+++ b/remarkable_fs/__init__.py
@@ -25,14 +25,15 @@ def main(argv = sys.argv):
     print("Connecting to reMarkable...")
     if remarkable_mount_point == None:
         with connect(*argv[2:]) as conn:
-            connect_to(DocumentRoot, conn, mount_point)
+            root = DocumentRoot(conn)
+            connect_to(root, mount_point)
     else:
         mount_point = os.path.abspath(mount_point)
         os.chdir( remarkable_mount_point )
-        connect_to(DocumentRootDir, None, mount_point)
+        root = DocumentRootDir()
+        connect_to(root, mount_point)
 
-def connect_to(connection_object, parameter, mount_point):
-    root = connection_object(parameter)
+def connect_to(root, mount_point):
     print("Now serving documents at " + mount_point)
     kwargs={}
     if fuse.system() == "Darwin":

--- a/remarkable_fs/documents.py
+++ b/remarkable_fs/documents.py
@@ -23,6 +23,8 @@ from lazy import lazy
 from progress.bar import Bar
 from io import BytesIO
 import remarkable_fs.rM2svg
+from collections import namedtuple
+
 
 try:
     from json import JSONDecodeError
@@ -350,10 +352,6 @@ class DocumentRoot(Collection):
         return file.name
 
 
-class StupidHack():
-    def __init__(self):
-        self.sftp = os
-
 class DocumentRootDir(DocumentRoot):
     """A collection representing the root of the reMarkable directory tree.
 
@@ -365,7 +363,10 @@ class DocumentRootDir(DocumentRoot):
 
     def __init__(self):
         """connection - a Connection object returned by remarkable_fs.connection.connect()."""
-        stupid = StupidHack()
+        FakeConnnection = namedtuple('FakeConnnection', 'sftp')
+        FakeSFTP = namedtuple('FakeSFTP', 'open listdir stat getcwd')
+        stupid = FakeConnnection(FakeSFTP(open, os.listdir, os.stat, os.getcwd))
+
         super(DocumentRootDir, self).__init__(stupid)
 
     def read_file(self, file):

--- a/remarkable_fs/documents.py
+++ b/remarkable_fs/documents.py
@@ -377,8 +377,7 @@ class DocumentRootDir(DocumentRoot):
     def write_file(self, file, data):
         """Write a file to SFTP."""
         with open(file, "wb") as f:
-            # f.set_pipelined()
-            f.write(data)
+            f.write(memoryview(data))
 
 
 class NoContents(Exception):

--- a/remarkable_fs/documents.py
+++ b/remarkable_fs/documents.py
@@ -363,24 +363,19 @@ class DocumentRootDir(DocumentRoot):
     filenames and the values are nodes. You can also use find_node() to look up
     a node by id."""
 
-    def __init__(self, remarkable_directory):
+    def __init__(self):
         """connection - a Connection object returned by remarkable_fs.connection.connect()."""
         stupid = StupidHack()
         super(DocumentRootDir, self).__init__(stupid)
 
-        if (remarkable_directory.endswith("/")):
-            self.remarkable_dir = remarkable_directory
-        else:
-            self.remarkable_dir = remarkable_directory + "/"
-
     def read_file(self, file):
         """Read a file from SFTP."""
-        with open(self.remarkable_dir + file, "rb") as f:
+        with open(file, "rb") as f:
             return f.read()
 
     def write_file(self, file, data):
         """Write a file to SFTP."""
-        with open(self.remarkable_dir + file, "wb") as f:
+        with open(file, "wb") as f:
             # f.set_pipelined()
             f.write(data)
 

--- a/remarkable_fs/documents.py
+++ b/remarkable_fs/documents.py
@@ -14,6 +14,7 @@ import fnmatch
 import json
 import time
 import os.path
+import os
 import itertools
 import traceback
 from tempfile import NamedTemporaryFile
@@ -347,6 +348,42 @@ class DocumentRoot(Collection):
             self.templates[name] = file
 
         return file.name
+
+
+class StupidHack():
+    def __init__(self):
+        self.sftp = os
+
+class DocumentRootDir(DocumentRoot):
+    """A collection representing the root of the reMarkable directory tree.
+
+    Creating one of these will read in all metadata and construct the directory hierarchy.
+
+    You can index into a DocumentRoot as if it was a dict. The keys are
+    filenames and the values are nodes. You can also use find_node() to look up
+    a node by id."""
+
+    def __init__(self, remarkable_directory):
+        """connection - a Connection object returned by remarkable_fs.connection.connect()."""
+        stupid = StupidHack()
+        super(DocumentRootDir, self).__init__(stupid)
+
+        if (remarkable_directory.endswith("/")):
+            self.remarkable_dir = remarkable_directory
+        else:
+            self.remarkable_dir = remarkable_directory + "/"
+
+    def read_file(self, file):
+        """Read a file from SFTP."""
+        with open(self.remarkable_dir + file, "rb") as f:
+            return f.read()
+
+    def write_file(self, file, data):
+        """Write a file to SFTP."""
+        with open(self.remarkable_dir + file, "wb") as f:
+            # f.set_pipelined()
+            f.write(data)
+
 
 class NoContents(Exception):
     """An exception that indicates that a document only has notes and no PDF or EPUB file."""


### PR DESCRIPTION
In the beginning this pull request was created. This may make a lot of people very angry and may be widely regarded as a bad move.

Somewhat seriously though, here is a pull request that, in a hopefully backwards-compatible way, creates an alternative backend where remarkable files are essentially just read and written in another folder, rather than to the ssh server. This creates a few interesting usecases:
- Allowing users with a backup of their reMarkable filesystem to be able to open/interact with the files on it locally
- Allowing users who have more complicated ssh setups (such as mine with many ssh keys etc.) that break the SFTP portion of the app to use their own setup (using existing solutions like autofs or sshfs) to access the files on their remarkable.
- Pretty much turns remarkable-fs into a file-converting utility where (hopefully, i didn't test this both ways) users can put files in either end and get them back out the other end in the converted format for doing whatever :tm: with. This may be especially useful to build into something like Calibre to allow users to sync their ebooks to their remarkable tablets through the existing interface

The part of this pull request that may make people angry is the way in which it was achieved. Since I figured this would make a useful upstream contribution, there are  some lines in `__init__` of my alternate `DocumentRootDir` class (better names welcome). This ugly hack basically is some nested `namedtuple`'s that essentially emulate the structure of the sftp object being passed around, replacing its methods like `open()`, `stat()`, .etc with their equivalents for opening regular files, such as python's standard `open` and various calls to `os` such as `os.stat`.

This mainly arose out of some errors I was having with the ssh implementation in this package due to my specific setup not playing super nice with the ssh library used here, so hopefully this also helps other people looking to get something to work on their system.

The one word of warning i have is that I noticed that the ssh connection code in this program intentionally disables, then re-enables `xochitl` while it is working, which this additional mode does not do, so while your remarkable may not freeze while copying files, that may mean your device is more likely to be bricked (i presume). 

Also, I would be happy to update the naming/docs on my fork to turn this into a separate project if it doesn't fit the goal of this project, just figured id make a pull request to give the option.